### PR TITLE
fix driver is executable now

### DIFF
--- a/src/main/java/io/github/bonigarcia/wdm/Downloader.java
+++ b/src/main/java/io/github/bonigarcia/wdm/Downloader.java
@@ -107,6 +107,7 @@ public class Downloader {
         } else if (targetFile.getName().toLowerCase().endsWith(".msi")) {
             return extractMsi(targetFile);
         } else {
+            setFileExecutable(targetFile);
             return targetFile;
         }
     }


### PR DESCRIPTION
drivers were not executable in case of "download from nexus" option